### PR TITLE
Add "any" as a valid value for `step` property

### DIFF
--- a/1/1.21.json
+++ b/1/1.21.json
@@ -616,7 +616,7 @@
 											"type": "string"
 										},
 										"then": {
-											"required": ["any"]
+											"enum": ["any"]
 										}
 									}
 								]

--- a/1/1.21.json
+++ b/1/1.21.json
@@ -600,9 +600,26 @@
 								"description": "The maximum value of the decimal."
 							},
 							"step": {
-								"type": "number",
+								"type": ["number", "string"],
 								"description": "The step value of the decimal.",
-								"minimum": 0
+								"allOf": [
+									{
+										"if": {
+											"type": "number"
+										},
+										"then": {
+											"minimum": 0
+										}
+									},
+									{
+										"if": {
+											"type": "string"
+										},
+										"then": {
+											"required": ["any"]
+										}
+									}
+								]
 							}
 						}
 					}


### PR DESCRIPTION
Makes "any" a valid option for the step property, to allow decimal settings without a set precision limit.

I'm just going to overwrite the current version of the schema because it's an incredibly minor change and the new decimal setting type is very new.

Tested.